### PR TITLE
Speed up test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
     "dist/"
   ],
   "scripts": {
-    "build": "rm -rf ./dist && tsc --project .",
+    "build:clean": "rimraf dist && yarn build",
+    "build": "tsc --project .",
     "lint": "eslint . --ext ts,js,json",
     "lint:fix": "yarn lint --fix",
     "test": "yarn build && node test",
-    "prepublishOnly": "yarn test"
+    "prepublishOnly": "yarn build:clean && yarn test"
   },
   "author": "",
   "license": "ISC",
@@ -36,6 +37,7 @@
     "eslint-plugin-json": "^2.1.2",
     "eslint-plugin-node": "^11.1.0",
     "pump": "^1.0.2",
+    "rimraf": "^3.0.2",
     "tape": "^4.8.0",
     "typescript": "^4.1.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,6 +1351,13 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 run-parallel@^1.1.9:
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"


### PR DESCRIPTION
The test script now builds and tests without removing the `dist` directory first. This speeds up the test script a little bit (~0.5 seconds for me, usually). Removing the directory seemed a bit excessive, particularly if someone had enabled incremental builds.

A new `build:clean` script has been added to remove `dist` and build, and this is used in the `prepublishOnly` script. This should ensure the build used for publishing is always complete, with no extraneous files.

Also `rimraf` is now used for deleting `dist`, to improve platform compatibility for contributors.