### PR TITLE
v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.2.0]
 ### Changed
-- Throw error if parent is destroyed or ended already when creating sub streams ([#17](https://github.com/MetaMask/object-multiplex/pull/17))
-- Rename package to @metamask/object-multiplex ([#12](https://github.com/MetaMask/object-multiplex/pull/12))
+- Throw error if parent is destroyed or ended already when creating sub streams ([#17](https://github.com/MetaMask/object-multiplex/pull/17), [#22](https://github.com/MetaMask/object-multiplex/pull/22))
+  - Such streams would have failed after the first write anyway. This failure case should be easier to deal with now that we're identifying it earlier, with a more helpful error message.
 
 ## [1.1.0] - 2020-12-07
 ### Added
 - TypeScript typings ([#9](https://github.com/MetaMask/object-multiplex/pull/9))
 
-[Unreleased]: https://github.com/MetaMask/object-multiplex/compare/v1.1.0...HEAD
+### Changed
+- Rename package to @metamask/object-multiplex ([#12](https://github.com/MetaMask/object-multiplex/pull/12))
+
+[Unreleased]: https://github.com/MetaMask/object-multiplex/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/MetaMask/object-multiplex/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/MetaMask/object-multiplex/releases/tag/v1.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/object-multiplex",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Simple stream multiplexing for objectMode.",
   "main": "dist/index.js",
   "repository": {


### PR DESCRIPTION
This release includes an enhancement to error handling.

The changelog has also been updated to include the package rename as part of v1.1.0, which is when that happened. Previously it was mistakenly under the 'Unreleased' section.