### PR TITLE
bump devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prettier": "^2.8.8",
     "rimraf": "^3.0.2",
     "tape": "^4.17.0",
-    "typescript": "^4.8.4"
+    "typescript": "~4.8.4"
   },
   "lavamoat": {
     "allowScripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2464,10 +2464,10 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
-typescript@^4.8.4:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@~4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
non-breaking maintenance updates. In particular, updates Typescript to 4.8.4.