### PR TITLE
v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0]
+### Changed
+- Allow overriding default stream constructor options in `createStream` ([#52](https://github.com/MetaMask/object-multiplex/pull/52))
+
 ## [2.0.0]
 ### Changed
 - **BREAKING**: Increase minimum Node.js version to 16 ([#41](https://github.com/MetaMask/object-multiplex/pull/41))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/object-multiplex",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Simple stream multiplexing for objectMode.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This is the release candidate for `@metamask/object-multiplex` v2.1.0.
