### PR TITLE
fix: move `@types/readable-stream` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@types/readable-stream": "4.0.0",
     "once": "^1.4.0",
     "readable-stream": "^3.6.2"
   },
@@ -39,7 +40,6 @@
     "@metamask/eslint-config-typescript": "^6.0.0",
     "@types/node": "^16",
     "@types/once": "^1.4.0",
-    "@types/readable-stream": "4.0.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "eslint": "^7.32.0",


### PR DESCRIPTION
## Explanation

Moves `@types/readable-stream` from `devDependencies` to `dependencies`.

The type declarations this package publishes to `dist/` reference types from `readable-stream` (e.g. `Duplex` in `ObjectMultiplex.d.ts` and `Substream.d.ts`), and `src/readable-stream.d.ts` augments the `readable-stream` module. Since `readable-stream@^3` ships no types of its own, these declarations only resolve through `@types/readable-stream` — so TypeScript consumers are currently forced to add it as their own dependency (see e.g. MetaMask/swaps-controller#333).

No `yarn.lock` change is needed: Yarn v1 lockfiles don't record dependency groups, and `yarn install --frozen-lockfile` passes unchanged.

## References

Fixes #58

## Changelog

### Fixed

- TypeScript consumers no longer need to install `@types/readable-stream` themselves: it is now a runtime dependency, since the published type declarations reference it

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate (no code change — `yarn build` and `node test` pass, 8/8)
- [x] I've updated documentation for new or updated code as appropriate (N/A)
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no application logic; slightly increases install footprint for non-TypeScript users.
> 
> **Overview**
> Moves **`@types/readable-stream`** from **`devDependencies`** to **`dependencies`** so it installs with the package.
> 
> Published **`dist/*.d.ts`** and **`src/readable-stream.d.ts`** rely on those types because **`readable-stream@^3`** does not ship its own. Without this, TypeScript consumers had to add **`@types/readable-stream`** themselves.
> 
> No runtime or source changes—only **`package.json`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc97090ff78f819fbd443038c311b927adb6b43b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->