### PR TITLE
fix: make @types/readable-stream a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@types/readable-stream": "4.0.0",
     "once": "^1.4.0",
     "readable-stream": "^3.6.2"
   },
@@ -39,7 +40,6 @@
     "@metamask/eslint-config-typescript": "^6.0.0",
     "@types/node": "^16",
     "@types/once": "^1.4.0",
-    "@types/readable-stream": "4.0.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "eslint": "^7.32.0",


### PR DESCRIPTION
## Description

`@types/readable-stream` is currently a devDependency, but the published type declarations (`dist/*.d.ts`) reference types from it. TypeScript consumers therefore fail to resolve the types unless they add `@types/readable-stream` as a dependency themselves — see e.g. https://github.com/MetaMask/swaps-controller/pull/333/files#r1829249847.

This moves `@types/readable-stream` from `devDependencies` to `dependencies` so it resolves transitively for consumers. No version change (`4.0.0`), no lockfile change.

Fixes #58

## Testing

- `yarn install --frozen-lockfile` — lockfile unchanged
- `yarn test` (builds with tsc + runs the tape suite) — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no runtime or API behavior changes; slightly increases install footprint for all consumers.
> 
> **Overview**
> **Fixes TypeScript resolution for package consumers** by moving `@types/readable-stream` from `devDependencies` to `dependencies` in `package.json`.
> 
> Published declarations under `dist/*.d.ts` pull in types from that package (via `readable-stream` usage and `src/readable-stream.d.ts` augmentation), so keeping it dev-only forced downstream projects to add the types themselves. Version stays pinned at `4.0.0`; no application or build logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92e2046425f95d61c6af1c1b48821872bbd59025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->