### PR TITLE
fix: publish readable-stream types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@types/readable-stream": "4.0.0",
     "once": "^1.4.0",
     "readable-stream": "^3.6.2"
   },
@@ -39,7 +40,6 @@
     "@metamask/eslint-config-typescript": "^6.0.0",
     "@types/node": "^16",
     "@types/once": "^1.4.0",
-    "@types/readable-stream": "4.0.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "eslint": "^7.32.0",


### PR DESCRIPTION
## Summary

Move `@types/readable-stream` from `devDependencies` to `dependencies`.

The package emits TypeScript declarations that import and augment `readable-stream`. Consumers compiling those declarations need the type package installed transitively.

## Verification

- `npx tsc --project .`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no application or runtime logic modified; slightly increases install footprint for all consumers.
> 
> **Overview**
> Moves **`@types/readable-stream`** from `devDependencies` to **`dependencies`** so it is installed for consumers of the published package.
> 
> Published `.d.ts` output (including module augmentation in `readable-stream.d.ts`) references `readable-stream` types; without this package as a transitive dependency, TypeScript projects that depend on `@metamask/object-multiplex` can fail to resolve those types at compile time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f855b7ac47a3070a9683eeda09afca5e6c8677a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->